### PR TITLE
load limit number of icons on startup

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -832,7 +832,7 @@ MyApplet.prototype = {
             this._previousTreeSelectedActor = null;
             this._previousSelectedActor = null;
             this.closeApplicationsContextMenus(null, false);
-            this._clearAllSelections();
+            this._clearAllSelections(false);
         }
     },
 
@@ -1461,7 +1461,7 @@ MyApplet.prototype = {
         this.catBoxIter = new VisibleChildIterator(this, this.categoriesBox);
         this.categoriesBox._vis_iter = this.catBoxIter;
         Mainloop.idle_add(Lang.bind(this, function() {
-            this._clearAllSelections();
+            this._clearAllSelections(true);
         }));
     },
 
@@ -1474,12 +1474,14 @@ MyApplet.prototype = {
         }
     },
 
-    _clearAllSelections: function() {
+    _clearAllSelections: function(hide_apps) {
         let actors = this.applicationsBox.get_children();
         for (var i=0; i<actors.length; i++) {
             let actor = actors[i];
             actor.style_class = "menu-application-button";
-            actor.hide();
+	    if (hide_apps) {
+		actor.hide();
+	    }
         }
         let actors = this.categoriesBox.get_children();
         for (var i=0; i<actors.length; i++){
@@ -1628,7 +1630,7 @@ MyApplet.prototype = {
      resetSearch: function(){
         this.searchEntry.set_text("");
         this.searchActive = false;
-        this._clearAllSelections();
+        this._clearAllSelections(true);
         this._setCategoriesButtonActive(true);
         global.stage.set_key_focus(this.searchEntry);
      },
@@ -1639,7 +1641,7 @@ MyApplet.prototype = {
             return;
         } else {
             this.searchActive = this.searchEntry.get_text() != '';
-            this._clearAllSelections();
+            this._clearAllSelections(true);
             if (this.searchActive) {
                 this.searchEntry.set_secondary_icon(this._searchActiveIcon);
                 if (this._searchIconClickedId == 0) {


### PR DESCRIPTION
This is patch loads a limited number of icons when the menu is displayed and then loads in the rest in the background.  This causes menus to appear to display immediately.  The scroll bar changes size, so it might be a good idea to disable scrolling until everything is loaded.
