### PR TITLE
[window-list] Purge alert-window list of destroyed windows.

### DIFF
--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -903,6 +903,11 @@ MyApplet.prototype = {
     calculate_alert_positions: function() {
         this._clean_alert_boxes();
 
+        // purge destroyed alert windows
+        this._alertWindows = this._alertWindows.filter(function(alertWindow) {
+            return alertWindow.metaWindow.get_workspace() != null;
+        }, this);
+
         let cur_ws_index = global.screen.get_active_workspace_index();
 
         for (let i = 0; i < this._alertWindows.length; i++ ) {
@@ -1018,6 +1023,7 @@ MyApplet.prototype = {
                 break;
             }
         }
+        this.calculate_alert_positions();
     },
     
     _changeWorkspaces: function() {


### PR DESCRIPTION
Hi,

I found that the list of alert-windows is not purged of destroyed windows, leaving zombie instances behind under some circumstances. How to reproduce:

1) start 'tests/interactive/urgentwindow.py'
2) quickly change to another workspace and wait for the alert
3) open Expo and close the "urgent window" without ever acknowledging the alert
4) exit Expo and switch workspaces a couple of times, paying attention to the console output.

Expected behavior: The destroyed alert-window should have been removed from the window list.
Actual behavior: The destroyed alert-window is left in the window list and the following is printed to the console:

```
    JS ERROR: !!!   Exception was: TypeError: this._alertWindows[i].metaWindow.get_workspace() is null
    JS ERROR: !!!     lineNumber = '909'
    JS ERROR: !!!     fileName = '"/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js"'
   JS ERROR: !!!     stack = '"()@/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js:909
([object _private_Cinnamon_WM],0,1,-4)@/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js:942
()@/usr/share/cinnamon/js/ui/windowManager.js:925
([object _private_Meta_Display],[object _private_Meta_Screen],null,[object _private_Meta_KeyBinding])@/usr/share/cinnamon/js/ui/windowManager.js:913
"'
   JS ERROR: !!!     message = '"this._alertWindows[i].metaWindow.get_workspace() is null"'
```
