### PR TITLE
[window-list] Purge alert-list when an alerting window receives focus.

### DIFF
--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -881,11 +881,14 @@ MyApplet.prototype = {
         for ( let i=0; i<this._windows.length; ++i ) {
             if ( this._windows[i].metaWindow == window ) {
                 if (this._windows[i].actor._delegate.getAttention()) {
+                    this._alertWindows = this._alertWindows.filter(function(alertWindow) {
+                        return alertWindow.metaWindow != window; // we don't want duplicates
+                    }, this);
                     let alertButton = new AppMenuButton(this, window, true, this.orientation, this._panelHeight, false);
                     this._alertWindows.push(alertButton);
                     this.calculate_alert_positions();
-                    return;
                 }
+                return;
             }
         }
     },


### PR DESCRIPTION
Hi again!

Sorry to be the bearer of bad news again, but it's still not working without annoying glitches. By running tests/interactive/urgentwindow.py, removing focus from the alerting window and switching back and forth between workspaces I am able to produce duplicate alert placeholders, and clicking on a placeholder leaves zombie placeholders behind.

This patch seems to fix these glitches. Hopefully for the last time.

Per
