### PR TITLE
Replace gnome-control-center Printers page by system-config-printer

### DIFF
--- a/files/usr/lib/cinnamon-settings/cinnamon-settings.py
+++ b/files/usr/lib/cinnamon-settings/cinnamon-settings.py
@@ -38,7 +38,6 @@ CONTROL_CENTER_MODULES = [
     [_("Display"),                          "display",            "display.svg",                    "prefs"],
     [_("Region & Keyboard Layout"),         "region",             "region.svg",                     "prefs"],
     [_("Bluetooth"),                        "bluetooth",          "bluetooth.svg",                  "admin"],
-    [_("Printers"),                         "printers",           "printer.svg",                    "admin"],
     [_("System Info & Default Programs"),   "info",               "details.svg",                    "admin"],
     [_("Universal Access"),                 "universal-access",   "universal-access.svg",           "prefs"],
     [_("User Accounts"),                    "user-accounts",      "user-accounts.svg",              "admin"],
@@ -48,6 +47,7 @@ CONTROL_CENTER_MODULES = [
 
 STANDALONE_MODULES = [
 #         Label                          Executable                          Icon                         Category
+    [_("Printers"),                      "system-config-printer",        "printer.svg",                   "admin"],
     [_("Firewall"),                      "gufw",                         "firewall.svg",                  "admin"],
     [_("Install/Remove Languages"),      "gnome-language-selector",      "language.svg",                  "admin"]
 ]


### PR DESCRIPTION
We may need to have the deb package depend on system-config-printer-gnome,
else it'll fail to open the Printers page on systems lacking this package.
