### PR TITLE
[GNOME 3.8][Alt-Tab] Use new alt-tab keybindings

### DIFF
--- a/files/usr/lib/cinnamon-settings/modules/cs_keyboard.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_keyboard.py
@@ -43,8 +43,8 @@ KEYBINDINGS = [
     # Cinnamon stuff
     [_("Toggle Scale"), "org.gnome.desktop.wm.keybindings", "switch-to-workspace-down", True, "cinnamon"],
     [_("Toggle Expo"), "org.gnome.desktop.wm.keybindings", "switch-to-workspace-up", True, "cinnamon"],
-    [_("Cycle through open windows"), "org.gnome.desktop.wm.keybindings", "switch-windows", True, "cinnamon"],
-    [_("Cycle backwards though open windows"), "org.gnome.desktop.wm.keybindings", "switch-windows-backward", True, "cinnamon"],
+    [_("Cycle through open windows"), "org.gnome.desktop.wm.keybindings", "switch-applications", True, "cinnamon"],
+    [_("Cycle backwards though open windows"), "org.gnome.desktop.wm.keybindings", "switch-applications-backward", True, "cinnamon"],
     [_("Run dialog (must restart Cinnamon)"), "org.gnome.desktop.wm.keybindings", "panel-run-dialog", True, "cinnamon"],
     [_("Menu button (must restart Cinnamon)"), "org.cinnamon.muffin", "overlay-key", False, "cinnamon"],
 

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -134,11 +134,11 @@ WindowManager.prototype = {
                                             Lang.bind(this, this._showWorkspaceSwitcher));
         Meta.keybindings_set_custom_handler('switch-to-workspace-down',
                                             Lang.bind(this, this._showWorkspaceSwitcher));
-        Meta.keybindings_set_custom_handler('switch-windows',
+        Meta.keybindings_set_custom_handler('switch-applications',
                                             Lang.bind(this, this._startAppSwitcher));
         Meta.keybindings_set_custom_handler('switch-group',
                                             Lang.bind(this, this._startAppSwitcher));
-        Meta.keybindings_set_custom_handler('switch-windows-backward',
+        Meta.keybindings_set_custom_handler('switch-applications-backward',
                                             Lang.bind(this, this._startAppSwitcher));
         Meta.keybindings_set_custom_handler('switch-group-backward',
                                             Lang.bind(this, this._startAppSwitcher));


### PR DESCRIPTION
Together with https://github.com/linuxmint/muffin/pull/81
