### PR TITLE
sound-applet: fix warning

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -243,6 +243,7 @@ Player.prototype = {
         this._busName = busname;
         this._applet = applet;
         this._name = this._busName.split('.')[3];
+        this._songLength = 0;
 
         Interfaces.getDBusProxyWithOwnerAsync(MEDIA_PLAYER_2_NAME,
                                               this._busName,


### PR DESCRIPTION
Cjs-Message: JS WARNING: [/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js 496]: reference to undefined property this._songLength